### PR TITLE
fix: explicity convert volume events to json dict

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,4 +1,4 @@
-import asyncio
+import json
 from decimal import Decimal
 from decimal import localcontext
 from eth_abi import abi
@@ -135,7 +135,7 @@ async def get_pool_supply_events(
 
         for block_num in range(from_block, to_block + 1):
             block_events = filter(lambda x: x['blockNumber'] == block_num, events)
-            event_dict[block_num] = [dict(event) for event in block_events]
+            event_dict[block_num] = [json.loads(Web3.to_json(event)) for event in block_events]
 
         return event_dict
 


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #12

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The generic worker component of snapshotter-lite can fail to deserialize the event data that is submitted as a part of the pool_supply_volume snapshot into a json compatible format causing the snapshot generation and submission to fail.

### New expected behaviour
The event data is correctly parsed into a json compatible dict as it is received from the `get_logs` request. The event data is now converted into json using a provided web3 library and then loaded into a python dict using the json library. This avoids the function failing to convert any AttributeDicts returned from the `get_logs` call when cast directly to a python `dict()`

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
- `helpers.py` - fixed the parsing of event data in `get_pool_supply_events()`


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
No Changes