### PR TITLE
Chore: eth uniswapv2 core redis cleanup

### DIFF
--- a/redis_keys.py
+++ b/redis_keys.py
@@ -10,46 +10,6 @@ uniswap_pair_contract_tokens_data = (
     'uniswap:pairContract:' + settings.namespace + ':{}:PairContractTokensData'
 )
 
-# Redis key for mapping Uniswap tokens to pair contract addresses
-uinswap_token_pair_contract_mapping = (
-    'uniswap:tokens:' + settings.namespace + ':PairContractAddress'
-)
-
-# Redis sorted set key for storing Uniswap V2 summarized snapshots
-uniswap_V2_summarized_snapshots_zset = (
-    'uniswap:V2PairsSummarySnapshot:' + settings.namespace + ':snapshotsZset'
-)
-
-# Redis key for storing Uniswap V2 snapshot at a specific block height
-uniswap_V2_snapshot_at_blockheight = (
-    'uniswap:V2PairsSummarySnapshot:' + settings.namespace + ':snapshot:{}'
-)  # {} is replaced with block_height
-
-# Redis sorted set key for storing Uniswap V2 daily stats snapshots
-uniswap_v2_daily_stats_snapshot_zset = (
-    'uniswap:V2DailyStatsSnapshot:' + settings.namespace + ':snapshotsZset'
-)
-
-# Redis key for storing Uniswap V2 daily stats at a specific block height
-uniswap_V2_daily_stats_at_blockheight = (
-    'uniswap:V2DailyStatsSnapshot:' + settings.namespace + ':snapshot:{}'
-)  # {} is replaced with block_height
-
-# Redis sorted set key for storing Uniswap V2 tokens snapshots
-uniswap_v2_tokens_snapshot_zset = (
-    'uniswap:V2TokensSummarySnapshot:' + settings.namespace + ':snapshotsZset'
-)
-
-# Redis key for storing Uniswap V2 tokens at a specific block height
-uniswap_V2_tokens_at_blockheight = (
-    'uniswap:V2TokensSummarySnapshot:' + settings.namespace + ':{}'
-)  # {} is replaced with block_height
-
-# Redis key for caching recent logs of a Uniswap pair contract
-uniswap_pair_cached_recent_logs = (
-    'uniswap:pairContract:' + settings.namespace + ':{}:recentLogs'
-)
-
 # Redis key for storing the mapping of Uniswap tokens to pairs
 uniswap_tokens_pair_map = (
     'uniswap:pairContract:' + settings.namespace + ':tokensPairMap'

--- a/utils/pricing.py
+++ b/utils/pricing.py
@@ -346,9 +346,18 @@ async def get_token_price_in_block_range(
                 for height, price in token_price_dict.items()
             }
 
-            await redis_conn.zadd(
-                name=uniswap_pair_cached_block_height_token_price.format(token_address),
-                mapping=redis_cache_mapping,
+            source_chain_epoch_size = int(await redis_conn.get(source_chain_epoch_size_key()))
+
+            await asyncio.gather(
+                redis_conn.zadd(
+                    name=uniswap_pair_cached_block_height_token_price.format(token_address),
+                    mapping=redis_cache_mapping,
+                ),
+                redis_conn.zremrangebyscore(
+                    name=uniswap_pair_cached_block_height_token_price.format(token_address),
+                    min=0,
+                    max=int(from_block) - source_chain_epoch_size * 4,
+                ),
             )
 
         return token_price_dict


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes # https://github.com/PowerLoom/snapshotter-core/issues/28

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The `uniswap_pair_cached_block_height_token_price` is not being pruned during node runtime which is causing the redis db size to be unbounded.

### New expected behaviour
Unused redis keys have been removed, and the `uniswap_pair_cached_block_height_token_price` is now correctly being pruned.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed
- `redis_keys.py`
- `utils/pricing.py`

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
No changes
