### PR TITLE
Feat/bds rpc helper

### DIFF
--- a/aggregate/multi_uniswap_stats.py
+++ b/aggregate/multi_uniswap_stats.py
@@ -1,5 +1,6 @@
 from ipfs_client.main import AsyncIPFSClient
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
 
 from computes.utils.models.message_models import UniswapPairTotalReservesSnapshot
 from computes.utils.models.message_models import UniswapStatsSnapshot
@@ -10,7 +11,6 @@ from snapshotter.utils.data_utils import get_submission_data_bulk
 from snapshotter.utils.data_utils import get_tail_epoch_id
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.models.message_models import PowerloomCalculateAggregateMessage
-from snapshotter.utils.rpc import RpcHelper
 
 
 class AggregateStatsProcessor(GenericProcessorAggregate):

--- a/aggregate/multi_uniswap_top_pairs_24h.py
+++ b/aggregate/multi_uniswap_top_pairs_24h.py
@@ -1,5 +1,6 @@
 from ipfs_client.main import AsyncIPFSClient
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
 
 from computes.utils.helpers import get_pair_metadata
 from computes.utils.models.message_models import UniswapPairTotalReservesSnapshot
@@ -10,7 +11,6 @@ from snapshotter.utils.callback_helpers import GenericProcessorAggregate
 from snapshotter.utils.data_utils import get_submission_data_bulk
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.models.message_models import PowerloomCalculateAggregateMessage
-from snapshotter.utils.rpc import RpcHelper
 
 
 class AggregateTopPairsProcessor(GenericProcessorAggregate):

--- a/aggregate/multi_uniswap_top_pairs_7d.py
+++ b/aggregate/multi_uniswap_top_pairs_7d.py
@@ -1,5 +1,6 @@
 from ipfs_client.main import AsyncIPFSClient
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
 
 from computes.utils.helpers import get_pair_metadata
 from computes.utils.models.message_models import UniswapTopPair7dSnapshot
@@ -9,7 +10,6 @@ from snapshotter.utils.callback_helpers import GenericProcessorAggregate
 from snapshotter.utils.data_utils import get_submission_data_bulk
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.models.message_models import PowerloomCalculateAggregateMessage
-from snapshotter.utils.rpc import RpcHelper
 
 
 class AggregateTopPairsProcessor(GenericProcessorAggregate):

--- a/aggregate/multi_uniswap_top_tokens.py
+++ b/aggregate/multi_uniswap_top_tokens.py
@@ -1,5 +1,6 @@
 from ipfs_client.main import AsyncIPFSClient
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
 
 from computes.utils.helpers import get_pair_metadata
 from computes.utils.models.message_models import UniswapPairTotalReservesSnapshot
@@ -12,7 +13,6 @@ from snapshotter.utils.data_utils import get_submission_data_bulk
 from snapshotter.utils.data_utils import get_tail_epoch_id
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.models.message_models import PowerloomCalculateAggregateMessage
-from snapshotter.utils.rpc import RpcHelper
 
 
 class AggregateTopTokensProcessor(GenericProcessorAggregate):

--- a/aggregate/single_uniswap_trade_volume_24h.py
+++ b/aggregate/single_uniswap_trade_volume_24h.py
@@ -3,6 +3,8 @@ import json
 
 from ipfs_client.main import AsyncIPFSClient
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
+
 from computes.utils.helpers import truncate
 from computes.utils.models.message_models import UniswapTradesAggregateSnapshot
 from computes.utils.models.message_models import UniswapTradesSnapshot
@@ -15,7 +17,6 @@ from snapshotter.utils.default_logger import logger
 from snapshotter.utils.models.message_models import PowerloomSnapshotSubmittedMessage
 from snapshotter.utils.redis.redis_keys import project_finalized_data_zset
 from snapshotter.utils.redis.redis_keys import submitted_base_snapshots_key
-from snapshotter.utils.rpc import RpcHelper
 
 
 class AggregateTradeVolumeProcessor(GenericProcessorAggregate):

--- a/aggregate/single_uniswap_trade_volume_7d.py
+++ b/aggregate/single_uniswap_trade_volume_7d.py
@@ -3,6 +3,8 @@ import asyncio
 import pydantic
 from ipfs_client.main import AsyncIPFSClient
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
+
 from computes.utils.helpers import truncate
 from computes.utils.models.message_models import UniswapTradesAggregateSnapshot
 from snapshotter.utils.callback_helpers import GenericProcessorAggregate
@@ -11,7 +13,6 @@ from snapshotter.utils.data_utils import get_submission_data
 from snapshotter.utils.data_utils import get_tail_epoch_id
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.models.message_models import PowerloomSnapshotSubmittedMessage
-from snapshotter.utils.rpc import RpcHelper
 
 
 class AggregateTradeVolumeProcessor(GenericProcessorAggregate):

--- a/liquidity_depth.py
+++ b/liquidity_depth.py
@@ -4,12 +4,12 @@ from typing import Optional
 from typing import Union
 
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
 
 from computes.utils.core import get_liquidity_depth
 from computes.utils.models.message_models import LiquidityDepthSnapshot
 from snapshotter.utils.callback_helpers import SnapshotProcessMessage
 from snapshotter.utils.default_logger import logger
-from snapshotter.utils.rpc import RpcHelper
 
 
 class LiquidityDepthProcessor(SnapshotProcessMessage):

--- a/pair_total_reserves.py
+++ b/pair_total_reserves.py
@@ -4,12 +4,12 @@ from typing import Optional
 from typing import Union
 
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
 
 from computes.utils.core import get_pair_reserves
 from snapshotter.utils.models.message_models import PowerloomSnapshotProcessMessage
 from snapshotter.utils.callback_helpers import GenericProcessorSnapshot
 from snapshotter.utils.default_logger import logger
-from snapshotter.utils.rpc import RpcHelper
 
 from computes.utils.models.message_models import EpochBaseSnapshot
 from computes.utils.models.message_models import UniswapPairTotalReservesSnapshot

--- a/preloaders/eth_price/preloader.py
+++ b/preloaders/eth_price/preloader.py
@@ -2,12 +2,13 @@ from redis import asyncio as aioredis
 import json
 import asyncio
 
+from rpc_helper.rpc import RpcHelper
+from rpc_helper.rpc import get_contract_abi_dict
+
 from snapshotter.utils.callback_helpers import GenericPreloader
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.models.message_models import EpochBase
-from snapshotter.utils.rpc import RpcHelper
 from snapshotter.utils.file_utils import read_json_file
-from snapshotter.utils.rpc import get_contract_abi_dict
 from computes.redis_keys import uniswap_eth_usd_price_zset
 from snapshotter.utils.redis.redis_keys import source_chain_epoch_size_key
 from computes.settings.config import settings as worker_settings

--- a/tests/pair_total_reserves_test.py
+++ b/tests/pair_total_reserves_test.py
@@ -1,9 +1,11 @@
 import asyncio
 
+from rpc_helper.rpc import RpcHelper
+
+from snapshotter.settings.config import settings
 from snapshotter.utils.models.message_models import PowerloomSnapshotProcessMessage
 from snapshotter.utils.redis.redis_conn import RedisPoolCache
 from snapshotter.utils.redis.redis_keys import source_chain_epoch_size_key
-from snapshotter.utils.rpc import RpcHelper
 
 from computes.pair_total_reserves import PairTotalReservesProcessor
 from computes.utils.models.message_models import UniswapPairTotalReservesSnapshot
@@ -21,7 +23,7 @@ async def test_pair_reserves_processor():
     )
 
     processor = PairTotalReservesProcessor()
-    rpc_helper = RpcHelper()
+    rpc_helper = RpcHelper(settings.rpc)
     aioredis_pool = RedisPoolCache()
     await aioredis_pool.populate()
     redis_conn = aioredis_pool._aioredis_pool

--- a/tests/test_get_eth_price.py
+++ b/tests/test_get_eth_price.py
@@ -1,9 +1,10 @@
 import pytest
 from pytest_asyncio import fixture as async_fixture
+from rpc_helper.rpc import RpcHelper
+
 from computes.preloaders.eth_price.preloader import EthPricePreloader
 from snapshotter.utils.redis.redis_keys import source_chain_epoch_size_key
 from computes.redis_keys import uniswap_eth_usd_price_zset
-from snapshotter.utils.rpc import RpcHelper
 from snapshotter.settings.config import settings
 from fakeredis import FakeAsyncRedis
 

--- a/tests/test_tick_caching.py
+++ b/tests/test_tick_caching.py
@@ -1,11 +1,13 @@
 from web3 import Web3
 import asyncio
 
+from rpc_helper.rpc import RpcHelper
+
 from computes.total_value_locked import calculate_reserves
 from computes.utils.helpers import get_pair_metadata
 from computes.redis_keys import uniswap_cached_tick_data_block_height
+from snapshotter.settings.config import settings
 from snapshotter.utils.redis.redis_conn import RedisPoolCache
-from snapshotter.utils.rpc import RpcHelper
 
 
 async def test_tick_cache():
@@ -14,7 +16,7 @@ async def test_tick_cache():
         "0x7858E59e0C01EA06Df3aF3D20aC7B0003275D4Bf"
     )
     from_block = 18766112
-    rpc_helper = RpcHelper()
+    rpc_helper = RpcHelper(settings.rpc)
     aioredis_pool = RedisPoolCache()
 
     await aioredis_pool.populate()

--- a/tests/test_tvl.py
+++ b/tests/test_tvl.py
@@ -2,12 +2,13 @@ import os
 from web3 import Web3
 import asyncio
 
+from rpc_helper.rpc import RpcHelper
+
 from computes.utils.constants import erc20_abi
 from computes.total_value_locked import _load_abi, calculate_reserves, calculate_tvl_from_ticks, get_tick_info
 from computes.utils.helpers import get_pair_metadata
 from snapshotter.settings.config import settings
 from snapshotter.utils.redis.redis_conn import RedisPoolCache
-from snapshotter.utils.rpc import RpcHelper
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -22,7 +23,7 @@ async def test_calculate_reserves():
     )
     from_block = 18931130
 
-    rpc_helper = RpcHelper()
+    rpc_helper = RpcHelper(settings.rpc)
     aioredis_pool = RedisPoolCache()
     query = """{
     pool(id: "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640", block: {number: 18931130}) {

--- a/tests/trade_volume_test.py
+++ b/tests/trade_volume_test.py
@@ -1,9 +1,11 @@
 import asyncio
 
+from rpc_helper.rpc import RpcHelper
+
+from snapshotter.settings.config import settings
 from snapshotter.utils.models.message_models import PowerloomSnapshotProcessMessage
 from snapshotter.utils.redis.redis_conn import RedisPoolCache
 from snapshotter.utils.redis.redis_keys import source_chain_epoch_size_key
-from snapshotter.utils.rpc import RpcHelper
 
 from computes.trade_volume import TradeVolumeProcessor
 from computes.utils.models.message_models import UniswapTradesSnapshot
@@ -21,7 +23,7 @@ async def test_trade_volume_processor():
     )
 
     processor = TradeVolumeProcessor()
-    rpc_helper = RpcHelper()
+    rpc_helper = RpcHelper(settings.rpc)
     aioredis_pool = RedisPoolCache()
     await aioredis_pool.populate()
     redis_conn = aioredis_pool._aioredis_pool

--- a/tests/web3_call_override_test.py
+++ b/tests/web3_call_override_test.py
@@ -1,16 +1,17 @@
 import pytest
 import functools
+from rpc_helper.rpc import RpcHelper
 from web3 import Web3
 
+from snapshotter.settings.config import settings
 from computes.utils.constants import univ3_helper_bytecode, override_address, helper_contract
 from computes.utils.constants import MAX_TICK, MIN_TICK
 from computes.total_value_locked import transform_tick_bytes_to_list
-from snapshotter.utils.rpc import RpcHelper
 
 @pytest.mark.asyncio
 async def test_web3_call_with_override():
     # Initialize RpcHelper
-    rpc_helper = RpcHelper()
+    rpc_helper = RpcHelper(settings.rpc)
     await rpc_helper.init()
 
     # Create overrides dictionary

--- a/total_value_locked.py
+++ b/total_value_locked.py
@@ -10,8 +10,8 @@ from eth_typing import Address
 from eth_typing.evm import Address
 from eth_typing.evm import ChecksumAddress
 from snapshotter.utils.default_logger import logger
-from snapshotter.utils.rpc import get_event_sig_and_abi
-from snapshotter.utils.rpc import RpcHelper
+from rpc_helper.rpc import get_event_sig_and_abi
+from rpc_helper.rpc import RpcHelper
 
 from computes.utils.constants import helper_contract
 from computes.utils.constants import MAX_TICK

--- a/trade_volume.py
+++ b/trade_volume.py
@@ -1,6 +1,7 @@
 import time
 
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
 
 from computes.utils.core import get_pair_trade_volume
 from computes.utils.models.message_models import EpochBaseSnapshot
@@ -8,7 +9,6 @@ from computes.utils.models.message_models import UniswapTradesSnapshot
 from snapshotter.utils.models.message_models import PowerloomSnapshotProcessMessage
 from snapshotter.utils.callback_helpers import GenericProcessorSnapshot
 from snapshotter.utils.default_logger import logger
-from snapshotter.utils.rpc import RpcHelper
 
 
 class TradeVolumeProcessor(GenericProcessorSnapshot):

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -3,9 +3,10 @@ This module contains constants and initializations for the Uniswap-related compu
 It sets up contract objects, loads ABIs, and defines various constants used throughout the project.
 """
 
+from snapshotter.settings.config import settings
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.file_utils import read_json_file
-from snapshotter.utils.rpc import RpcHelper
+from rpc_helper.rpc import RpcHelper
 from web3 import Web3
 import asyncio
 import threading
@@ -37,7 +38,7 @@ univ3_helper_bytecode = univ3_helper_bytecode_json['bytecode']
 
 # Initialize RPC helper and get current node
 # Initialize RPC helper and get current node
-rpc_helper = RpcHelper()
+rpc_helper = RpcHelper(settings.rpc)
 _rpc_initialized = False
 _rpc_init_lock = threading.Lock() # Lock to prevent race conditions if imported concurrently
 

--- a/utils/core.py
+++ b/utils/core.py
@@ -4,8 +4,8 @@ from functools import reduce
 
 from redis import asyncio as aioredis
 from snapshotter.utils.default_logger import logger
-from snapshotter.utils.rpc import get_event_sig_and_abi
-from snapshotter.utils.rpc import RpcHelper
+from rpc_helper.rpc import get_event_sig_and_abi
+from rpc_helper.rpc import RpcHelper
 from snapshotter.utils.snapshot_utils import get_block_details_in_block_range
 from web3 import Web3
 

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -6,8 +6,8 @@ from asyncio import gather
 from redis import asyncio as aioredis
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.redis.redis_keys import source_chain_epoch_size_key
-from snapshotter.utils.rpc import get_contract_abi_dict
-from snapshotter.utils.rpc import RpcHelper
+from rpc_helper.rpc import get_contract_abi_dict
+from rpc_helper.rpc import RpcHelper
 from web3 import Web3
 
 from computes.redis_keys import uniswap_cached_block_height_token_eth_price

--- a/utils/pricing.py
+++ b/utils/pricing.py
@@ -2,6 +2,7 @@ import json
 
 from asyncio import gather
 from redis import asyncio as aioredis
+from rpc_helper.rpc import RpcHelper
 from web3 import Web3
 
 from computes.preloaders.eth_price.preloader import eth_price_preloader
@@ -10,7 +11,6 @@ from computes.redis_keys import uniswap_pair_cached_block_height_token_price
 from computes.settings.config import settings as worker_settings
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.redis.redis_keys import source_chain_epoch_size_key
-from snapshotter.utils.rpc import RpcHelper
 
 
 pricing_logger = logger.bind(module="PowerLoom|Uniswap|Pricing")


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #15

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
`bds_uni_v3` uses an RPC utility integrated within the project structure. RPC interactions across various modules rely on this internal implementation.

### New expected behaviour
This merge refactors the codebase to utilize an external `rpc_helper` library for all Ethereum RPC interactions. All modules that previously imported `RpcHelper` or related RPC functions from `snapshotter.utils.rpc` are updated to import from `rpc_helper.rpc`. The initialization of `RpcHelper` is also updated in several places (especially in tests and constants) to explicitly pass configuration from `settings.rpc`. The core logic of the computes should remain the same, but the underlying RPC communication layer is standardized to use the external library.

### Change logs

#### Added
- Dependency on the external `rpc_helper` library

#### Changed
- Updated import paths for `RpcHelper`, `get_event_sig_and_abi`, and `get_contract_abi_dict` from `snapshotter.utils.rpc` to `rpc_helper.rpc` across numerous files, including:
    - `aggregate/*.py`
    - `preloaders/eth_price/preloader.py`
    - `tests/*.py`
    - `utils/constants.py`
    - `utils/core.py`
    - `utils/helpers.py`
    - `utils/pricing.py`
    - `liquidity_depth.py`
    - `pair_total_reserves.py`
    - `total_value_locked.py`
    - `trade_volume.py`
- Modified `RpcHelper` instantiation in various files (e.g., `tests/*`, `utils/constants.py`) to pass `settings.rpc` during initialization.

#### Removed
- Removed usage of the internal `snapshotter.utils.rpc` module/classes for RPC interactions.

## Deployment Instructions
- Ensure the external `rpc_helper` library is added as a dependency and installed (e.g., via `poetry install`).
- Verify that the RPC configuration specified in `settings.rpc` is correct and compatible with the external `rpc_helper` library's requirements.